### PR TITLE
🔧 Update canonical tag (site_url)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Eric Bouchut
-site_url: https://ericbouchut.com
+site_url: https://www.ericbouchut.com
 
 theme:
   name: material
@@ -90,4 +90,3 @@ nav:
 
 repo_url: https://github.com/ebouchut/ebouchut.github.io
 repo_name: ebouchut/ebouchut.github.io
-


### PR DESCRIPTION
The GitHub Pages custom domain is now `www.ericbouchut.com`.
I added a DNS `CNAME` entry `www` pointing to `ebouchut.github.io.`.

This PR is the missing piece, to let mkdocs, Google Search Console, and others know that the canonical tag (base URL) is now `https://www.ericbouchut.com/` via `site_url`.